### PR TITLE
Encountered a bug whereby a column that was expected by the code (bec…

### DIFF
--- a/src/class_affe_data_getter.py
+++ b/src/class_affe_data_getter.py
@@ -354,10 +354,20 @@ class AffeDataGetter:
         if not df.empty:
             counter = 0
             for col_name in list_with_ordered_column_names:
-                col = df[col_name]
-                df.drop(columns=[col_name], inplace=True)
-                df.insert(loc=counter, column=col_name, value=col)
-                counter += 1
+                # I believe the metadata on OpenSea storefront can be modified. I've run into
+                # a situation where some columns I expected to find are no longer there (and
+                # I'm guessing that's because these were attributes that at some point were given
+                # to a token, but later removed. This made the code crash at this point. So
+                # now here, for safety, I'll check if the column name is in the 'df', and if
+                # it isn't, I won't execute the code, but rather issue a warning.
+                if col_name in df.columns:
+                    col = df[col_name]
+                    df.drop(columns=[col_name], inplace=True)
+                    df.insert(loc=counter, column=col_name, value=col)
+                    counter += 1
+                else:
+                    logging.warning(f"While re-ordering columns, expected to find a column named '{col_name}', but "
+                                    f"it was not present in the data.")
 
         df.to_csv(self.fullpath_final, index=False)
         return df

--- a/src/get_affe_data.py
+++ b/src/get_affe_data.py
@@ -17,6 +17,6 @@ if __name__ == "__main__":
     opensea_storefront = "0x495f947276749ce646f68ac8c248420045cb7b5e"
     full_path_data_dir = Path(getenv('DATA_PATH'))
     affe_getter = AffeDataGetter(opensea_storefront, full_path_data_dir)
-    affe_getter.build_affen_data_files(request_moralis_metadata_resync=False)
+    affe_getter.build_affen_data_files(request_moralis_metadata_resync=False, use_data_already_on_disk=False)
     affe_manip = AffeDataManipulator(affe_getter.load_previously_fetched_data(), full_path_data_dir)
     affe_manip.dump_all_to_json()


### PR DESCRIPTION
…ause it is stated in a list that

dictates the re-ordering of columns), was not found. This is probably
because it was removed from the online metadata (possibly removed as an
attribute from a token on the OpenSea Storefront). So added an if
statement to check for the existence of each column in a df before
trying to manipulate it.